### PR TITLE
Fix docker name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,4 +113,4 @@ ci-local:
 docker:
 	docker run -ti --rm -v `pwd`:/home/ubuntu/fuzzolic \
 		-v `pwd`/../fuzzolic-evaluation/benchmarks/:/home/ubuntu/benchmarks \
-		ercoppa/fuzzolic-runner-v1 bash
+		ercoppa/fuzzolic-runner-v1:ubuntu2004 bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@
 ## Docker container
 A prebuilt container image is available on Docker Hub. You can pull and launch it with:
 ```
-$ docker run -ti --rm ercoppa/fuzzolic-runner-v1
+$ docker run -ti --rm ercoppa/fuzzolic-runner-v1:ubuntu2004
 ```
 
 ## Manual build


### PR DESCRIPTION
Hi,

according to the https://github.com/season-lab/fuzzolic/issues/9 it should be used the `ercoppa/fuzzolic-runner-v1:ubuntu2004` docker image, but in the Makefile and documentation still there is old name. This PR update it.