### PR TITLE
fix: executor fails to kill solver if it hangs

### DIFF
--- a/fuzzolic/executor.py
+++ b/fuzzolic/executor.py
@@ -449,7 +449,7 @@ class Executor(object):
                 print('[FUZZOLIC] Solver is taking too long. Let us stop it.')
                 p_solver.send_signal(signal.SIGUSR2)
                 try:
-                    p_solver.wait(SOLVER_TIMEOUT)
+                    p_solver.wait(SOLVER_TIMEOUT / 1000)
                 except subprocess.TimeoutExpired:
                     print('[FUZZOLIC] Solver will be killed.')
                     p_solver.send_signal(signal.SIGKILL)


### PR DESCRIPTION
SOLVER_TIMEOUT is in milliseconds, but p_solver.wait should be in seconds

This causes 1000 second hangs during hybrid fuzzing when the solver misbehaves.